### PR TITLE
Add survey of agency tools

### DIFF
--- a/survey-of-agency-tools.md
+++ b/survey-of-agency-tools.md
@@ -1,0 +1,149 @@
+# Survey of agency performance tools
+
+_Non-authoritative performance.gov research, curated by 18F, a digital
+consultancy in the US federal government._
+
+Agencies use many different software packages for tracking and collecting
+performance data. The tools listed here were included by 16 CFO agencies as part
+of a [survey](https://drive.google.com/drive/folders/0B2stDO5hLAHkZUxPYy04X3F3dk0)
+for performance.gov.
+
+We can't guarantee the accuracy of this page–it represents initial research
+of team members, and could be incomplete or become out-of-date.
+
+
+## Performance tools
+
+### Budget Formulation and Execution Manager (BFEM)
+
+Used by Treasury, NASA, DOE, DOI, and others. About [14 agencies in
+total](https://www.tcg.com/our-work/treasury-budget-formulation-execution-manager-bfem-more-bang-for-your-buck/).
+
+Created and [administered by the
+Treasury](https://arc.publicdebt.treas.gov/financial_management_budget_formulation.htm).
+Other agencies can pay a fee to use the system.
+
+> The Administrative Resource Center (ARC) provides strategic planning, budget
+> formulation, and performance management shared services to federal agencies
+> and organizations using the BFEM application.
+
+[BFEM](https://bfem.gov/bfem/login.seam?cid=33544) can be used for budget and
+performance management. Focused on providing various reports for congress and
+OMB. Can produce strategic planning documents with links to performance and
+budget data.
+
+Can export data in excel and other formats.
+
+
+### Departmental E-Budgeting Suite (DEBS)
+
+Used by DOL.
+
+Homegrown internal-only system in use since 2007. Also sometimes referred to as
+the Departmental E-Business Suite.
+
+> The Departmental E-Budgeting System (DEBS) is an integrated budget environment
+> that blends a set of COTS and GOTS solutions to optimize resources throughout the budget
+> formulation lifecycle. The set of tools and techniques associated with DEBS
+> permits users to track, spread, report and analyze budget and performance data
+> within agencies and across DOL for greater transparency.
+
+https://www.dol.gov/dol/budget/2008/PDF/E300-2008-019.pdf
+
+Seems to be focused on creating budget reports, less about data and data
+visualizations or performance tracking.
+
+
+### IBM Cognos
+
+Used by OPM.
+
+General business intelligence [cloud-based tool](https://www.ibm.com/products/cognos-analytics).
+
+> Experience IBM Cognos Analytics, an interactive way for virtually anyone to
+> find, explore, and share data-driven insights in a governed environment. Find
+> precise and timely answers from your data or from content built by others.
+> Create compelling reports and dashboards which you can easily distribute
+> throughout your company. Use automated alerts to monitor changes to key
+> findings. Confidently and quickly take actions to improve your business.
+
+Rich features for building dashboards and custom visualizations. "Smarts" to
+guess the best visualization for your data. No mention of export or API
+features.
+
+
+### BFS
+
+Used by EPA.
+
+Private, homegrown, [internal-only tool](https://bfssb.epa.gov/Account/Login?ReturnUrl=%2f).
+
+> The Budget Formulation System (BFS) is replacing EPA’s legacy Budget
+> Automation System (BAS) system. It enables agency staff to formulate budgets,
+> integrate budgets with strategic and annual performance plans, track financial
+> actuals against established budgets, model future payroll needs, and more.
+
+Can create pre-defined visualizations and reports. Some kind of
+limited export is supported.
+
+
+### FACTSInfo
+
+[Foreign Assistance Coordination and Tracking System (FACTSInfo)](https://www.usaid.gov/data/dataset/adfec9e6-635b-435a-a0a5-1e2d2a40450a).
+
+> Foreign assistance planning and reporting system for USAID and Department of
+> State (DOS); supports both reporting needs and transactional budget planning
+> and formulation. Primary users are DOS, Office of the Global AIDS Coordinator
+> (OGAC), and USAID.
+
+Owned by the State Department and shared with USAID.
+
+Internal, private [system](http://pdf.usaid.gov/pdf_docs/PCAAB918.pdf)
+containing budget data, mission strategic plans, and operational plans.
+
+
+### Oracle BI
+
+Used by DHS.
+
+[Oracle Business Intelligence
+12c](https://www.oracle.com/solutions/business-analytics/business-intelligence/index.html).
+Focused on general business intelligence and analytics.
+
+> Foster a data-driven culture with powerful, visually stunning analytics.
+> Explore new insights and empower people across the organization to make
+> faster, more informed business decisions.
+
+Export of data and reports is not featured, but [support
+articles](https://docs.oracle.com/cloud/otbi11116/bifgen/BIFGN/exporting_report.htm)
+show that exporting individual reports and maybe raw data is possible.
+
+
+### Program Performance Tracking System
+
+Used by HHS.
+
+An online [web
+portal](https://hhs-ppts.od.nih.gov/plexus/control?fromPage=x&toPage=/jsp/applications/visualscorecard/login.jsp&actionName=Cm_GotoPage)
+for managing HHS performance, budget, and Moyer Reports.
+
+An instance of the Plexus Scientific [Program Performance
+Manager](http://www.plexsci.com/program-performance-manager).
+
+> Unlike generalized performance management tools, PPM is specifically designed
+> to support government programs and GPRA reporting. PPM provides an integrated
+> platform for strategic planning, risk management, budget management,
+> performance management, and data analytics.
+
+Focus on combining budget, performance, risk, and strategy data. Emphasis on
+GPRA reporting compliance.
+
+- Creates ad hoc visualizations and reports
+- Export data to Microsoft Excel
+
+
+### Agency Level MI Dashboard
+
+Used by SSA.
+
+???


### PR DESCRIPTION
A quick survey and technical assessment of the agency performance tools. All of these are proprietary and most are internal-only tools, so I can only assess based on the information publicly available. I was looking at these through the lens of interoperability–how could these tools be used to export or supply data to performance.gov or similar platform?

Part of #28 